### PR TITLE
Update _config.yml to work under Jekyll 3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
-markdown: kramdown
-pygments: true
+kramdown:
+  syntax_highlighter: rouge
+
+gems: [jekyll-paginate]
 paginate: 3


### PR DESCRIPTION
Jekyll 3 now uses Kramdown by default and default syntax highlighter is now rouge.
Gem jekyll-paginate is now explicitly required to be called in config.yml gems array.

Deprecation warnings no longer show after changes.
